### PR TITLE
prereq cleanup

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -41,7 +41,6 @@ my(%params) =
 		'File::Spec' => 3.30,
 		'File::Temp' => 0.22,
 		'strict'     => 0,
-		'UNIVERSAL'  => 0,
 		'utf8'       => 0,
 	},
 	TEST_REQUIRES =>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,6 @@ my(%params) =
 	TEST_REQUIRES =>
 	{
 		'Test::More'	=> 1.001002,
-		'Test::Pod'		=> 1.51,
 	},
 	VERSION_FROM => 'lib/Config/Tiny.pm',
 	INSTALLDIRS  => 'site',

--- a/t/00.versions.t
+++ b/t/00.versions.t
@@ -12,7 +12,6 @@ use Test::More;
 use File::Spec;
 use File::Temp;
 use strict;
-use UNIVERSAL;
 use utf8;
 
 # ----------------------
@@ -24,7 +23,6 @@ my(@modules) = qw
 	File::Spec
 	File::Temp
 	strict
-	UNIVERSAL
 	utf8
 /;
 

--- a/t/02.main.t
+++ b/t/02.main.t
@@ -15,8 +15,6 @@ use File::Temp;
 
 use Test::More tests => 33;
 
-use UNIVERSAL ();
-
 # Warning: There is another version line, in lib/Config/Tiny.pm.
 
 our $VERSION = '2.24';


### PR DESCRIPTION
Test::Pod is an unnecessary prereq of this module, as it is only used in author tests.