### PR TITLE
Add ability to pass a hashref to constructor

### DIFF
--- a/lib/Config/Tiny.pm
+++ b/lib/Config/Tiny.pm
@@ -13,9 +13,9 @@ BEGIN {
 	$Config::Tiny::errstr  = '';
 }
 
-# Create an empty object.
+# Create an object.
 
-sub new { return bless {}, shift }
+sub new { return bless defined $_[1] ? $_[1] : {}, $_[0] }
 
 # Create an object from a file.
 
@@ -181,8 +181,13 @@ Config::Tiny - Read/Write .ini style files with as little code as possible
 	# In your program
 	use Config::Tiny;
 
-	# Create a config
+	# Create an empty config
 	my $Config = Config::Tiny->new;
+
+	# Create a config with data
+	my $config = Config::Tiny->new({
+		_ => { rootproperty => "Bar" },
+		section => { one => "value", Foo => 42 } });
 
 	# Open the config
 	$Config = Config::Tiny->read( 'file.conf' );
@@ -259,9 +264,16 @@ Returns a string representing the most recent error, or the empty string.
 
 You can also retrieve the error message from the C<$Config::Tiny::errstr> variable.
 
-=head2 new()
+=head2 new([$config])
 
-The constructor C<new> creates and returns an empty C<Config::Tiny> object.
+Here, the [] indicate an optional parameter.
+
+The constructor C<new> creates and returns a C<Config::Tiny> object.
+
+This will normally be a new, empty configuration, but you may also pass a
+hashref here which will be turned into an object of this class. This hashref
+should have a structure suitable for a configuration file, that is, a hash of
+hashes where the key C<_> is treated specially as the root section.
 
 =head2 read($filename, [$encoding])
 

--- a/t/08.constructor.t
+++ b/t/08.constructor.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl
+
+use Config::Tiny;
+
+use Test::More tests => 4;
+
+# ------------------------
+
+my($conf1) = Config::Tiny -> new( { _=>{foo=>"bar"} } );
+my($str1)  = $conf1->write_string;
+is $str1, "foo=bar\n";
+
+my($conf2) = Config::Tiny -> new( { _=>{hello=>"world"}, Cool=>{Beans=>"Dude",someval=>123} } );
+my($str2)  = $conf2->write_string;
+is $str2, <<'EOF';
+hello=world
+
+[Cool]
+Beans=Dude
+someval=123
+EOF
+
+my($conf3) = Config::Tiny -> new( { one => { alpha=>"aaa", beta=>"bbb" },
+	two => { abc => 123, def => 456, ghi => 789 } } );
+my($str3)  = $conf3->write_string;
+is $str3, <<'EOF';
+[one]
+alpha=aaa
+beta=bbb
+
+[two]
+abc=123
+def=456
+ghi=789
+EOF
+
+# from synopsis:
+my $config = Config::Tiny->new({
+	_ => { rootproperty => "Bar" },
+	section => { one => "value", Foo => 42 } });
+is $config->write_string, <<'EOF';
+rootproperty=Bar
+
+[section]
+Foo=42
+one=value
+EOF
+


### PR DESCRIPTION
With only a single-line change in the code, users  may now say `Config::Tiny->new($hashref)` to bless the hashref into the package and turn it into a `Config::Tiny` object. Tests and documentation are included.