### PR TITLE
remove unnecessary Test::Pod dep again

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,7 +45,6 @@ my(%params) =
 	TEST_REQUIRES =>
 	{
 		'Test::More'	=> '1.001002',
-		'Test::Pod'		=> '1.51',
 	},
 	VERSION_FROM => 'lib/Config/Tiny.pm',
 );


### PR DESCRIPTION
It looks like this was removed in #3, but the subsequent manual merge of #2 added it back.

I don't know much about this, but it seems that the removal was in fact correct, since on a system without Test::Pod installed, I was able to build and run tests without error:
```
$ perl -e 'use Test::More;'
$ perl -e 'use Test::Pod;'
Can't locate Test/Pod.pm in @INC (you may need to install the Test::Pod module) [...]
[ expected failure, verifying its absence ]
$ perl Makefile.PL
Writing Makefile for Config::Tiny
Writing MYMETA.yml and MYMETA.json
$ make
cp lib/Config/Tiny.pm blib/lib/Config/Tiny.pm
Manifying blib/man3/Config::Tiny.3pm
$ make test
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00.versions.t .......... 1/? # Testing Config::Tiny V 2.28
# Using File::Spec V 3.40
# Using File::Temp V 0.23
# Using strict V 1.07
# Using utf8 V 1.10
t/00.versions.t .......... ok
t/01.compile.t ........... ok
t/02.main.t .............. ok
t/03.read.string.t ....... ok
t/04.utf8.t .............. ok
t/05.zero.t .............. ok
t/06.repeat.key.t ........ ok
t/07.trailing.comment.t .. ok
t/08.constructor.t ....... ok
All tests successful.
Files=9, Tests=61,  0 wallclock secs ( 0.08 usr  0.10 sys +  0.34 cusr  0.15 csys =  0.67 CPU)
Result: PASS
```