### PR TITLE
Add arrays, defined with the characters "[]" after a key name

### DIFF
--- a/lib/Config/Tiny.pm
+++ b/lib/Config/Tiny.pm
@@ -84,6 +84,14 @@ sub read_string
 
 		if ( /^\s*([^=]+?)\s*=\s*(.*?)\s*$/ )
 		{
+			if ( substr($1, -2) eq '[]' )
+			{
+				my $k = substr $1, 0, -2;
+				$self->{$ns}->{$k} ||= [ ];
+				return $self -> _error ("Can't mix arrays and scalars at line $counter" ) unless ref $self->{$ns}->{$k} eq 'ARRAY';
+				push @{$self->{$ns}->{$k}}, $2;
+				next;
+			}
 			$self->{$ns}->{$1} = $2;
 
 			next;
@@ -144,6 +152,13 @@ sub write_string
 		{
 			return $self->_error("Illegal newlines in property '$section.$property'") if $block->{$property} =~ /(?:\012|\015)/s;
 
+			if (ref $block->{$property} eq 'ARRAY') {
+				for my $element ( @{$block->{$property}} )
+				{
+					$contents .= "${property}[]=$element\n";
+				}
+				next;
+			}
 			$contents .= "$property=$block->{$property}\n";
 		}
 	}

--- a/t/02.main.t
+++ b/t/02.main.t
@@ -50,6 +50,7 @@ my $expected = {
 		one => 'two',
 		Foo => 'Bar',
 		this => 'Your Mother!',
+		array => [ 'foo', 'bar' ],
 		blank => '',
 	},
 	'Section Two' => {

--- a/t/test.conf
+++ b/t/test.conf
@@ -3,6 +3,8 @@ root=something
 [section]
 one=two
 Foo=Bar
+array[]=foo
+array[]=bar
 this=Your Mother!
 blank=
 


### PR DESCRIPTION
Several suggestions have been made on the web to add arrays to INI files.
This branch has implemented the method of adding square brackets after the key name.